### PR TITLE
Optimize employee locations SQL to prevent daily pipeline hangs

### DIFF
--- a/scripts_notebooks/prod/sql_queries.py
+++ b/scripts_notebooks/prod/sql_queries.py
@@ -100,16 +100,29 @@ GROUP BY b.ProviderContactId
 ORDER BY b.ProviderContactId;
 """
 
-# SQL query template for employee locations (maps provider names to office locations)
+# SQL query template for employee locations (maps provider names to office locations).
+# Pre-dedupes Provider in a CTE so the outer join input is smaller, filters out
+# NULL names on both sides (can never match), and drops the ORDER BY since
+# downstream pandas code does not rely on row order.
 EMPLOYEE_LOCATIONS_SQL_TEMPLATE = """
+WITH p AS (
+    SELECT DISTINCT
+        ProviderFirstName,
+        ProviderLastName,
+        ProviderOfficeLocationName
+    FROM [insights].[insights].[Provider]
+    WHERE ProviderFirstName IS NOT NULL
+      AND ProviderLastName IS NOT NULL
+)
 SELECT DISTINCT
     c.ContactId AS ProviderContactId,
     c.FirstName AS ProviderFirstName,
     c.LastName AS ProviderLastName,
     p.ProviderOfficeLocationName AS WorkLocation
 FROM [insights].[dw2].[Contacts] AS c
-INNER JOIN [insights].[insights].[Provider] AS p
+INNER JOIN p
     ON p.ProviderFirstName = c.FirstName
    AND p.ProviderLastName = c.LastName
-ORDER BY c.LastName, c.FirstName;
+WHERE c.FirstName IS NOT NULL
+  AND c.LastName IS NOT NULL;
 """


### PR DESCRIPTION
## Summary
- Pre-dedupes `[insights].[insights].[Provider]` inside a CTE so the outer name-based join has a smaller input and the outer `DISTINCT` has far less row multiplication to clean up.
- Adds `WHERE FirstName IS NOT NULL AND LastName IS NOT NULL` on both sides — NULL names can never match, so we skip the compare work.
- Drops the outer `ORDER BY c.LastName, c.FirstName`. Downstream (`merge_data.py`) builds a `ProviderContactId -> WorkLocation` dict and writes the dataframe to an Excel sheet; neither depends on row order, so this was a pure server-side sort cost.

## Context
The daily 7 AM scheduled run hung twice in a row (2026-04-12 19:29 and 2026-04-13 07:00) on `execute_employee_locations_query`, killing both jobs. The root cause is the query itself: a full-table name-based join on `Contacts x Provider` with a top-level `DISTINCT` + `ORDER BY`, no integer key available (confirmed — `Provider` has no `ContactId`-equivalent column). These changes are the semantics-preserving wins that don't require a schema change.

## Test plan
- [ ] Run the updated query directly in the DWH and confirm it returns the same row count and the same `(ProviderContactId, WorkLocation)` mapping as the previous version
- [ ] Merge and confirm tomorrow's 7 AM scheduled run completes the employee locations phase in a reasonable time
- [ ] Spot-check that the `EmployeeLocationInCR` sheet in the output Excel still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)