### PR TITLE
Fix duplicate provider rows from client transfers

### DIFF
--- a/scripts_notebooks/prod/merge_data.py
+++ b/scripts_notebooks/prod/merge_data.py
@@ -301,7 +301,21 @@ def add_work_locations_from_sql(final_df: pd.DataFrame, employee_locations_df: p
             logger.info(f"Updated Clinic column with cleaned WorkLocation (provider office location) for {mask.sum()} rows")
         # For rows without WorkLocation, keep original Clinic value (client office location)
         logger.info(f"Kept original Clinic value (client office location) for {len(final_df) - mask.sum()} rows without WorkLocation")
-    
+
+    # Re-aggregate after Clinic override to collapse rows that now share the same provider+clinic
+    pre_agg_count = len(final_df)
+    numeric_cols = ['DirectHours', 'SupervisionHours', 'BACBSupervisionHours', 'TotalSupervisionHours']
+    numeric_cols = [c for c in numeric_cols if c in final_df.columns]
+    first_cols = [c for c in final_df.columns if c not in numeric_cols + ['DirectProviderId', 'Clinic', 'TotalSupervisionPercent']]
+    agg_dict = {c: 'sum' for c in numeric_cols}
+    agg_dict.update({c: 'first' for c in first_cols})
+    final_df = final_df.groupby(['DirectProviderId', 'Clinic'], dropna=False).agg(agg_dict).reset_index()
+    if 'DirectHours' in final_df.columns and 'TotalSupervisionHours' in final_df.columns:
+        direct_hours = final_df['DirectHours'].replace(0, pd.NA)
+        final_df['TotalSupervisionPercent'] = (100 * final_df['TotalSupervisionHours'] / direct_hours).round(2)
+    if pre_agg_count != len(final_df):
+        logger.info(f"Re-aggregated after WorkLocation override: {pre_agg_count} -> {len(final_df)} rows (collapsed {pre_agg_count - len(final_df)} duplicates)")
+
     return final_df
 
 


### PR DESCRIPTION
## Summary
- When a client transfers between clinics mid-month (e.g., Durham North → Wake Forest East), their `ClientOfficeLocationName` updates retroactively, causing `transform_data` to create separate rows per provider for each client clinic
- `merge_data` then overrides `Clinic` with the provider's `WorkLocation`, collapsing those different clinic names to the same value — but without re-aggregating, producing duplicate rows on the same tab
- Added re-aggregation after the `WorkLocation` override that sums hours and recalculates `TotalSupervisionPercent`, eliminating 56 duplicate rows in current data (737 → 681)

## Test plan
- [x] Ran full pipeline against June 2026 data — confirmed 0 duplicate providers per clinic (was 49)
- [x] Verified row counts: 737 → 681 after re-aggregation
- [x] Verified `TotalSupervisionPercent` recalculated correctly after summing

🤖 Generated with [Claude Code](https://claude.com/claude-code)