### PR TITLE
Fix BACB hours double-counted when collapsing duplicate RBT rows

### DIFF
--- a/scripts_notebooks/prod/merge_data.py
+++ b/scripts_notebooks/prod/merge_data.py
@@ -302,17 +302,39 @@ def add_work_locations_from_sql(final_df: pd.DataFrame, employee_locations_df: p
         # For rows without WorkLocation, keep original Clinic value (client office location)
         logger.info(f"Kept original Clinic value (client office location) for {len(final_df) - mask.sum()} rows without WorkLocation")
 
-    # Re-aggregate after Clinic override to collapse rows that now share the same provider+clinic
+    # Re-aggregate after the Clinic override to collapse rows that now share the
+    # same provider+clinic. transform_data produces one row per (provider, client
+    # office location); a provider whose hours span multiple client locations then
+    # has all those rows mapped onto a single clinic tab by the WorkLocation
+    # override above, leaving the same RBT on several rows of one tab.
     pre_agg_count = len(final_df)
-    numeric_cols = ['DirectHours', 'SupervisionHours', 'BACBSupervisionHours', 'TotalSupervisionHours']
-    numeric_cols = [c for c in numeric_cols if c in final_df.columns]
-    first_cols = [c for c in final_df.columns if c not in numeric_cols + ['DirectProviderId', 'Clinic', 'TotalSupervisionPercent']]
-    agg_dict = {c: 'sum' for c in numeric_cols}
+    original_cols = final_df.columns.tolist()
+
+    # DirectHours / SupervisionHours genuinely differ per client office location and
+    # are summed. BACB values are joined per-provider (on DirectProviderId only), so
+    # every duplicate row carries the SAME value and must be taken with 'first' --
+    # summing them double-counts BACB for a provider with split rows. The Total*
+    # columns are recomputed from the collapsed values below.
+    sum_cols = [c for c in ['DirectHours', 'SupervisionHours'] if c in final_df.columns]
+    recomputed_cols = ['TotalSupervisionHours', 'TotalSupervisionPercent']
+    first_cols = [c for c in final_df.columns
+                  if c not in sum_cols + recomputed_cols + ['DirectProviderId', 'Clinic']]
+
+    agg_dict = {c: 'sum' for c in sum_cols}
     agg_dict.update({c: 'first' for c in first_cols})
     final_df = final_df.groupby(['DirectProviderId', 'Clinic'], dropna=False).agg(agg_dict).reset_index()
+
+    # Recompute derived columns from the collapsed hours.
+    if 'SupervisionHours' in final_df.columns:
+        bacb_hours = final_df['BACBSupervisionHours'] if 'BACBSupervisionHours' in final_df.columns else 0
+        final_df['TotalSupervisionHours'] = final_df['SupervisionHours'] + bacb_hours
     if 'DirectHours' in final_df.columns and 'TotalSupervisionHours' in final_df.columns:
         direct_hours = final_df['DirectHours'].replace(0, pd.NA)
         final_df['TotalSupervisionPercent'] = (100 * final_df['TotalSupervisionHours'] / direct_hours).round(2)
+
+    # Restore the original column order.
+    final_df = final_df[[c for c in original_cols if c in final_df.columns]]
+
     if pre_agg_count != len(final_df):
         logger.info(f"Re-aggregated after WorkLocation override: {pre_agg_count} -> {len(final_df)} rows (collapsed {pre_agg_count - len(final_df)} duplicates)")
 


### PR DESCRIPTION
## Summary

Corrects a data-accuracy bug in the duplicate-row collapse added in `efdb9e5`.

That commit re-aggregates rows sharing the same `(provider, clinic)` after the WorkLocation override, but it **summed** `BACBSupervisionHours` and `TotalSupervisionHours` across the collapsed rows. BACB hours are joined **per-provider** (on `DirectProviderId` only), so every duplicate row for a provider carries the *same* BACB value — summing them **double-counts** BACB hours, `TotalSupervisionHours`, and `TotalSupervisionPercent` for any RBT who had BACB hours **and** split rows.

## Change

- Sum only `DirectHours` and `SupervisionHours` (these genuinely differ per client office location).
- Take `BACBSupervisionHours` / `BACBSupervisionCodesOccurred` with `first` (per-provider constants).
- Recompute `TotalSupervisionHours` and `TotalSupervisionPercent` from the collapsed values.
- Restore original column order after the groupby.

## Validation

Ran the real transform→merge path on `2026-06-25`:
- Duplicate `(provider, clinic)` rows: **0**
- `DirectHours` / `SupervisionHours` totals: **unchanged** (53468.77 / 4187.05)
- **33 providers** with BACB hours + split rows corrected (e.g. provider 3788486: BACB 0.5 → 0.25)
- BACB total now matches per-provider truth (205.90), not inflated

Synthetic unit test confirms a provider with BACB=5 on two split rows collapses to BACB=5 (not 10), Total=8, %=50.

## Context / follow-ups (not in this PR)

- This PR is part of resolving why RBT trackers still showed duplicates in production: the deployment machine's local `main` had diverged and its daily `git pull` was failing (corrupt `.git` refs from OneDrive-written `desktop.ini`), so it ran stale code from before `efdb9e5`. The local Windows wrapper (`run_pipeline_wrapper.bat`, gitignored) has been hardened to clean those files, use `--ff-only`, and log pull failures loudly instead of falsely reporting success.
- The unpushed local commit `4930f1b` (employee-locations query timeout fix) is preserved on a backup branch and will be integrated into the caching path in a separate, DB-tested PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)