### PR TITLE
Add LocationReview tab flagging likely un-updated clinic transfers

### DIFF
--- a/scripts_notebooks/prod/location_review.py
+++ b/scripts_notebooks/prod/location_review.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Location Review flag
+
+The daily tracker places each BT on the clinic tab named by their CentralReach
+provider-profile Office Location field (Provider.ProviderOfficeLocationName, carried
+through the pipeline as WorkLocation). That field is maintained by hand, so when a BT
+transfers clinics but the profile is not updated, they keep showing on their old
+clinic's roster even though all their sessions are now delivered elsewhere.
+
+This module does NOT change how BTs are assigned to tabs. It keeps the CentralReach
+Office Location as the source of truth and instead builds a review list: for each BT it
+compares their profile Office Location against the clinic where they have actually been
+delivering the most sessions over a recent lookback window, and flags the ones that
+disagree so business can update the stale CentralReach profiles.
+"""
+
+import logging
+
+import pandas as pd
+
+from transform_data import clean_clinic_name
+
+
+# A BT is flagged only when the recent service signal is strong enough to be a real
+# transfer rather than incidental cross-coverage at another clinic.
+DEFAULT_MIN_SESSIONS = 8        # ignore BTs with very little recent direct-service activity
+DEFAULT_DOMINANT_SHARE = 0.60   # their busiest clinic must be >=60% of recent sessions
+
+
+def _norm(value) -> str:
+    """Normalize a clinic name for comparison only (display keeps the original)."""
+    if pd.isna(value):
+        return ''
+    cleaned = clean_clinic_name(value)
+    if pd.isna(cleaned):
+        return ''
+    return str(cleaned).strip().casefold()
+
+
+def build_location_review(
+    employee_locations_df: pd.DataFrame,
+    recent_service_df: pd.DataFrame,
+    logger: logging.Logger = None,
+    min_sessions: int = DEFAULT_MIN_SESSIONS,
+    dominant_share: float = DEFAULT_DOMINANT_SHARE,
+) -> pd.DataFrame:
+    """
+    Build the Location Review flag list.
+
+    Args:
+        employee_locations_df: Employee locations from SQL (ProviderContactId,
+            ProviderFirstName, ProviderLastName, WorkLocation = profile Office Location).
+        recent_service_df: Recent service locations from SQL (ProviderContactId,
+            ServiceLocation, Sessions, LastServiceDate) aggregated per provider+location.
+        logger: Logger instance (optional).
+        min_sessions: Minimum recent direct-service sessions for a BT to be considered.
+        dominant_share: Minimum share of recent sessions at the busiest clinic.
+
+    Returns:
+        pd.DataFrame: One row per flagged BT (may be empty), with the columns:
+            ProviderName, ProfileOfficeLocation (CentralReach), RecentServiceLocation,
+            SessionsAtRecentLocation, ShareAtRecentLocation, TotalRecentSessions,
+            LastServiceDate.
+    """
+    if logger is None:
+        logger = logging.getLogger(__name__)
+
+    review_columns = [
+        'ProviderName',
+        'ProfileOfficeLocation (CentralReach)',
+        'RecentServiceLocation',
+        'SessionsAtRecentLocation',
+        'ShareAtRecentLocation',
+        'TotalRecentSessions',
+        'LastServiceDate',
+    ]
+
+    if recent_service_df is None or len(recent_service_df) == 0:
+        logger.info("Location review: no recent service data available, skipping flag")
+        return pd.DataFrame(columns=review_columns)
+    if employee_locations_df is None or len(employee_locations_df) == 0:
+        logger.info("Location review: no employee locations available, skipping flag")
+        return pd.DataFrame(columns=review_columns)
+
+    svc = recent_service_df.copy()
+    svc = svc[svc['ProviderContactId'].notna() & svc['ServiceLocation'].notna()]
+    svc['Sessions'] = pd.to_numeric(svc['Sessions'], errors='coerce').fillna(0).astype(int)
+    svc['LastServiceDate'] = pd.to_datetime(svc['LastServiceDate'], errors='coerce')
+
+    # Total recent sessions per provider, and the busiest (dominant) clinic per provider.
+    totals = svc.groupby('ProviderContactId', as_index=False)['Sessions'].sum()
+    totals = totals.rename(columns={'Sessions': 'TotalRecentSessions'})
+
+    # Keep the whole busiest row per provider (drop_duplicates keeps the first row
+    # intact, unlike groupby().first() which takes the first non-null value per column
+    # independently and could pull LastServiceDate from a different location's row).
+    dominant = (
+        svc.sort_values(['ProviderContactId', 'Sessions', 'LastServiceDate'],
+                        ascending=[True, False, False])
+           .drop_duplicates(subset='ProviderContactId', keep='first')
+           .reset_index(drop=True)
+    )
+    dominant = dominant.merge(totals, on='ProviderContactId', how='left')
+
+    # Profile Office Location per provider (one row per ProviderContactId).
+    profile = employee_locations_df.copy()
+    profile = profile[profile['ProviderContactId'].notna()]
+    profile = profile.drop_duplicates(subset=['ProviderContactId'], keep='first')
+
+    merged = dominant.merge(profile, on='ProviderContactId', how='inner')
+    if len(merged) == 0:
+        logger.info("Location review: no providers common to service data and profiles")
+        return pd.DataFrame(columns=review_columns)
+
+    merged['share'] = merged['Sessions'] / merged['TotalRecentSessions'].where(
+        merged['TotalRecentSessions'] > 0, other=pd.NA
+    )
+
+    def _is_flagged(row) -> bool:
+        profile_loc = row.get('WorkLocation')
+        # No profile location on file: the pipeline already falls back to service
+        # location for these, so there is nothing stale to flag.
+        if pd.isna(profile_loc) or str(profile_loc).strip() == '':
+            return False
+        if row['TotalRecentSessions'] < min_sessions:
+            return False
+        if pd.isna(row['share']) or row['share'] < dominant_share:
+            return False
+        return _norm(row['ServiceLocation']) != _norm(profile_loc)
+
+    merged['flagged'] = merged.apply(_is_flagged, axis=1)
+    flagged = merged[merged['flagged']].copy()
+
+    if len(flagged) == 0:
+        logger.info("Location review: no BTs flagged (all profile locations match recent service)")
+        return pd.DataFrame(columns=review_columns)
+
+    def _full_name(row) -> str:
+        first = '' if pd.isna(row.get('ProviderFirstName')) else str(row.get('ProviderFirstName')).strip()
+        last = '' if pd.isna(row.get('ProviderLastName')) else str(row.get('ProviderLastName')).strip()
+        return f"{first} {last}".strip()
+
+    out = pd.DataFrame({
+        'ProviderName': flagged.apply(_full_name, axis=1),
+        'ProfileOfficeLocation (CentralReach)': flagged['WorkLocation'].apply(clean_clinic_name),
+        'RecentServiceLocation': flagged['ServiceLocation'].apply(clean_clinic_name),
+        'SessionsAtRecentLocation': flagged['Sessions'].astype(int),
+        'ShareAtRecentLocation': (flagged['share'] * 100).round(0).astype(int).astype(str) + '%',
+        'TotalRecentSessions': flagged['TotalRecentSessions'].astype(int),
+        'LastServiceDate': flagged['LastServiceDate'].dt.strftime('%Y-%m-%d'),
+    })
+
+    # Most-transferred-looking first: highest share, then most sessions.
+    out['_share_num'] = flagged['share'].values
+    out = out.sort_values(
+        ['_share_num', 'SessionsAtRecentLocation'], ascending=[False, False]
+    ).drop(columns='_share_num').reset_index(drop=True)
+
+    logger.info(f"Location review: flagged {len(out)} BT(s) whose profile clinic differs from recent service clinic")
+    return out

--- a/scripts_notebooks/prod/merge_data.py
+++ b/scripts_notebooks/prod/merge_data.py
@@ -19,6 +19,7 @@ from openpyxl import load_workbook
 from openpyxl.formatting.rule import CellIsRule, FormulaRule
 from openpyxl.styles import PatternFill
 from transform_data import clean_clinic_name
+from location_review import build_location_review
 
 
 def setup_logging(log_dir: str = None) -> logging.Logger:
@@ -341,8 +342,41 @@ def add_work_locations_from_sql(final_df: pd.DataFrame, employee_locations_df: p
     return final_df
 
 
+LOCATION_REVIEW_SHEET_NAME = 'LocationReview'
+
+
+def write_location_review_sheet(writer, location_review_df: pd.DataFrame, logger: logging.Logger) -> None:
+    """
+    Write the Location Review sheet (flagged BTs whose CentralReach profile clinic
+    differs from where they actually deliver sessions). If nothing is flagged, still
+    write the sheet with a short note so the tab is present and its absence is never
+    mistaken for the check not running.
+    """
+    if location_review_df is None:
+        return
+    if len(location_review_df) > 0:
+        location_review_df.to_excel(writer, sheet_name=LOCATION_REVIEW_SHEET_NAME, index=False)
+        logger.info(f"  - Saved {len(location_review_df)} flagged BT(s) to sheet '{LOCATION_REVIEW_SHEET_NAME}'")
+    else:
+        note = pd.DataFrame({
+            'ProviderName': [],
+            'ProfileOfficeLocation (CentralReach)': [],
+            'RecentServiceLocation': [],
+        })
+        note = pd.concat([
+            note,
+            pd.DataFrame([{
+                'ProviderName': 'No BTs flagged - every profile Office Location matches recent service location.',
+                'ProfileOfficeLocation (CentralReach)': '',
+                'RecentServiceLocation': '',
+            }])
+        ], ignore_index=True)
+        note.to_excel(writer, sheet_name=LOCATION_REVIEW_SHEET_NAME, index=False)
+        logger.info(f"  - No BTs flagged; wrote placeholder note to sheet '{LOCATION_REVIEW_SHEET_NAME}'")
+
+
 def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame = None,
-                   employee_locations_df: pd.DataFrame = None,
+                   employee_locations_df: pd.DataFrame = None, recent_service_df: pd.DataFrame = None,
                    transformed_file: str = None, bacb_file: str = None, save_file: bool = True,
                    output_file: str = None, save_to_archive: bool = False, archive_date: str = None,
                    archive_file_exists: bool = False) -> pd.DataFrame:
@@ -353,6 +387,7 @@ def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame =
         transformed_df (pd.DataFrame, optional): Transformed DataFrame. If None, will read from transformed_file.
         bacb_df (pd.DataFrame, optional): BACB DataFrame. If None, will read from bacb_file.
         employee_locations_df (pd.DataFrame, optional): Employee locations DataFrame from SQL query. Used to add WorkLocation column.
+        recent_service_df (pd.DataFrame, optional): Recent service-delivery locations from SQL query. Used to build the Location Review flag tab (does not affect tab assignment).
         transformed_file (str, optional): Transformed CSV file path. Used if transformed_df is None.
         bacb_file (str, optional): BACB CSV file path. Used if bacb_df is None.
         save_file (bool): Whether to save file to disk. Default True.
@@ -412,7 +447,12 @@ def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame =
     # Add work locations from SQL query if available
     if employee_locations_df is not None and len(employee_locations_df) > 0:
         final_df = add_work_locations_from_sql(final_df, employee_locations_df, logger)
-    
+
+    # Build the Location Review flag: BTs whose CentralReach profile Office Location no
+    # longer matches where they are actually delivering sessions (likely un-updated
+    # clinic transfers). This is a review list only; it does not change tab assignment.
+    location_review_df = build_location_review(employee_locations_df, recent_service_df, logger)
+
     if save_file:
         today = datetime.now().strftime('%Y-%m-%d')
         archive_folder = f'../../data/transformed_supervision_daily/archived'
@@ -484,7 +524,7 @@ def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame =
             # "z_NoOfficeLocationListed" will naturally sort last due to the "z_" prefix
             clinics_sorted = sorted(clinics, key=lambda c: str(c).upper())
             logger.info(f"Sorted clinics alphabetically")
-            
+
             with pd.ExcelWriter(output_file, engine='openpyxl') as writer:
                 # Add employee locations tab as the first sheet
                 if employee_locations_df is not None and len(employee_locations_df) > 0:
@@ -496,7 +536,10 @@ def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame =
                     logger.info(f"  - Saved {len(employee_locations_display)} rows to sheet 'EmployeeLocationInCR'")
                 else:
                     logger.warning("  - Employee locations data not available, skipping 'EmployeeLocationInCR' sheet")
-                
+
+                # Location Review tab (flagged clinic-transfer mismatches), after the CR reference sheet
+                write_location_review_sheet(writer, location_review_df, logger)
+
                 for clinic in clinics_sorted:
                     clinic_data = final_df[final_df['Clinic'] == clinic].copy()
                     
@@ -640,7 +683,7 @@ def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame =
             
             # Sort clinics alphabetically (case-insensitive)
             clinics_sorted = sorted(clinics, key=lambda c: str(c).upper())
-            
+
             with pd.ExcelWriter(output_file, engine='openpyxl') as writer:
                 # Add employee locations tab as the first sheet
                 if employee_locations_df is not None and len(employee_locations_df) > 0:
@@ -652,7 +695,10 @@ def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame =
                     logger.info(f"  - Saved {len(employee_locations_display)} rows to sheet 'EmployeeLocationInCR'")
                 else:
                     logger.warning("  - Employee locations data not available, skipping 'EmployeeLocationInCR' sheet")
-                
+
+                # Location Review tab (flagged clinic-transfer mismatches), after the CR reference sheet
+                write_location_review_sheet(writer, location_review_df, logger)
+
                 for clinic in clinics_sorted:
                     clinic_data = final_df[final_df['Clinic'] == clinic].copy()
                     
@@ -806,7 +852,10 @@ def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame =
                     logger.info(f"  - Saved {len(employee_locations_display)} rows to sheet 'EmployeeLocationInCR'")
                 else:
                     logger.warning("  - Employee locations data not available, skipping 'EmployeeLocationInCR' sheet")
-                
+
+                # Location Review tab (flagged clinic-transfer mismatches), after the CR reference sheet
+                write_location_review_sheet(writer, location_review_df, logger)
+
                 # Add the main data sheet
                 final_df.to_excel(writer, sheet_name='Data', index=False)
             

--- a/scripts_notebooks/prod/pull_data.py
+++ b/scripts_notebooks/prod/pull_data.py
@@ -25,7 +25,13 @@ from sql_queries import (
     BACB_SUPERVISION_TEMPLATE,
     EMPLOYEE_LOCATIONS_SQL_TEMPLATE,
     EMPLOYEE_LOCATIONS_FRESHNESS_SQL,
+    RECENT_SERVICE_LOCATION_SQL_TEMPLATE,
 )
+
+# Lookback window (days) for the Location Review flag: how far back to look at each
+# BT's actual service-delivery locations when checking their CentralReach profile
+# Office Location for a likely un-updated clinic transfer.
+RECENT_SERVICE_LOOKBACK_DAYS = 45
 
 
 # Cache for employee_locations query results, keyed on the source tables'
@@ -305,7 +311,52 @@ def execute_employee_locations_query(conn, provider_ids: set) -> pd.DataFrame:
     return df
 
 
-def pull_data_main(start_date: str = None, end_date: str = None, save_files: bool = True) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+def execute_recent_service_location_query(conn, provider_ids: set,
+                                          lookback_days: int = RECENT_SERVICE_LOOKBACK_DAYS) -> pd.DataFrame:
+    """
+    Pull each BT's recent service-delivery locations, aggregated per provider+clinic.
+
+    Used to build the Location Review flag (see location_review.build_location_review):
+    the returned data is compared against each provider's CentralReach profile Office
+    Location to surface BTs whose profile clinic no longer matches where they actually
+    work (i.e. likely un-updated clinic transfers). This does NOT affect tab assignment.
+
+    The lookback window is anchored to "now" (independent of the pull's start/end date)
+    so the flag always reflects the BT's current clinic, even during the days 1-5
+    previous-month run.
+
+    Args:
+        conn: Database connection.
+        provider_ids: Set of ProviderContactId values to scope the query to (same set
+            used for the employee-locations pull).
+        lookback_days: How many days back to look at service delivery.
+
+    Returns:
+        pd.DataFrame: ProviderContactId, ServiceLocation, Sessions, LastServiceDate
+            (one row per provider+location). Empty if provider_ids is empty.
+    """
+    if not provider_ids:
+        logging.warning("No provider IDs supplied for recent service location query, skipping")
+        return pd.DataFrame(columns=['ProviderContactId', 'ServiceLocation', 'Sessions', 'LastServiceDate'])
+
+    now = datetime.now()
+    lookback_start = (now - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
+    end_date = (now + timedelta(days=1)).strftime('%Y-%m-%d')
+
+    id_list = ", ".join(str(int(pid)) for pid in provider_ids)
+    sql_query = RECENT_SERVICE_LOCATION_SQL_TEMPLATE.format(
+        lookback_start=lookback_start, end_date=end_date, provider_ids=id_list
+    )
+    logging.info(
+        f"Executing recent service location query ({lookback_days}-day lookback from "
+        f"{lookback_start}) for {len(provider_ids)} providers..."
+    )
+    df = pd.read_sql(sql_query, conn)
+    logging.info(f"Recent service location query returned {len(df)} provider+location rows")
+    return df
+
+
+def pull_data_main(start_date: str = None, end_date: str = None, save_files: bool = True) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """
     Main function to pull data from database.
     
@@ -315,7 +366,8 @@ def pull_data_main(start_date: str = None, end_date: str = None, save_files: boo
         save_files (bool): Whether to save files to disk. Default True.
         
     Returns:
-        Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]: (direct_df, supervision_df, bacb_df, employee_locations_df)
+        Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+            (direct_df, supervision_df, bacb_df, employee_locations_df, recent_service_location_df)
     """
     # Load environment variables
     load_dotenv()
@@ -395,7 +447,13 @@ def pull_data_main(start_date: str = None, end_date: str = None, save_files: boo
                 int(pid) for pid in _df['ProviderContactId'].dropna().unique()
             )
     employee_locations_df = execute_employee_locations_query(conn, provider_ids)
-    
+
+    # Execute recent service location query (for the Location Review flag), scoped to
+    # the same providers. Anchored to a fixed recent lookback window, independent of
+    # the pull's date range, so it always reflects each BT's current clinic.
+    logger.info("Pulling recent service location data (for Location Review flag)...")
+    recent_service_location_df = execute_recent_service_location_query(conn, provider_ids)
+
     # Close connection
     conn.close()
     
@@ -423,13 +481,19 @@ def pull_data_main(start_date: str = None, end_date: str = None, save_files: boo
         os.makedirs(os.path.dirname(employee_locations_output), exist_ok=True)
         employee_locations_df.to_csv(employee_locations_output, index=False)
         logger.info(f"Saved employee locations data to: {employee_locations_output}")
-    
+
+        # Save recent service location data
+        recent_service_output = f'../../data/raw_pulls/recent_service_locations_{today_str}.csv'
+        os.makedirs(os.path.dirname(recent_service_output), exist_ok=True)
+        recent_service_location_df.to_csv(recent_service_output, index=False)
+        logger.info(f"Saved recent service location data to: {recent_service_output}")
+
     logger.info("="*50)
     logger.info(f"Data pull completed successfully!")
-    logger.info(f"Direct: {len(direct_df)} rows, Supervision: {len(supervision_df)} rows, BACB: {len(bacb_df)} rows, Employee Locations: {len(employee_locations_df)} rows")
+    logger.info(f"Direct: {len(direct_df)} rows, Supervision: {len(supervision_df)} rows, BACB: {len(bacb_df)} rows, Employee Locations: {len(employee_locations_df)} rows, Recent Service Locations: {len(recent_service_location_df)} rows")
     logger.info("="*50)
-    
-    return direct_df, supervision_df, bacb_df, employee_locations_df
+
+    return direct_df, supervision_df, bacb_df, employee_locations_df, recent_service_location_df
 
 
 def main():

--- a/scripts_notebooks/prod/run_pipeline.py
+++ b/scripts_notebooks/prod/run_pipeline.py
@@ -209,7 +209,7 @@ def run_pipeline_phases(start_date: str = None, end_date: str = None,
         logger.info("PHASE 1: PULLING DATA FROM DATABASE")
         logger.info("="*70)
         logger.info("Executing pull_data.py...")
-        direct_df, supervision_df, bacb_df, employee_locations_df = pull_data_main(start_date=start_date, end_date=end_date, save_files=True)
+        direct_df, supervision_df, bacb_df, employee_locations_df, recent_service_location_df = pull_data_main(start_date=start_date, end_date=end_date, save_files=True)
         logger.info("Phase 1 completed successfully")
         
         # Phase 2: Join direct and supervision data
@@ -236,7 +236,8 @@ def run_pipeline_phases(start_date: str = None, end_date: str = None,
         logger.info("PHASE 4: MERGING DATA")
         logger.info("="*70)
         logger.info("Executing merge_data.py...")
-        final_df = merge_data_main(transformed_df=transformed_df, bacb_df=bacb_df, employee_locations_df=employee_locations_df, 
+        final_df = merge_data_main(transformed_df=transformed_df, bacb_df=bacb_df, employee_locations_df=employee_locations_df,
+                                  recent_service_df=recent_service_location_df,
                                   save_file=True, save_to_archive=save_to_archive, archive_date=archive_date,
                                   archive_file_exists=archive_file_exists)
         logger.info("Phase 4 completed successfully")

--- a/scripts_notebooks/prod/sql_queries.py
+++ b/scripts_notebooks/prod/sql_queries.py
@@ -136,3 +136,31 @@ SELECT
     (SELECT MAX(RowModifiedAt)  FROM [insights].[insights].[Provider]) AS provider_row_modified_at,
     (SELECT MAX(LastLoadedDate) FROM [insights].[dw2].[Contacts])      AS contacts_last_loaded_date;
 """
+
+# SQL query template for each BT's recent service-delivery locations. For direct
+# service (97153 / PDS | Technicians) over a recent lookback window, aggregates the
+# number of sessions and the most-recent session date per (provider, client office
+# location). Downstream code (location_review.build_location_review) compares each
+# provider's dominant service location against their CentralReach profile Office
+# Location (WorkLocation) to flag likely un-updated clinic transfers.
+#
+# Scoped to the same {provider_ids} set as the employee-locations pull so the flag
+# covers exactly the providers on the tracker and stays cheap. It is an aggregate
+# (GROUP BY), so the returned payload is one row per provider+location, not per session.
+RECENT_SERVICE_LOCATION_SQL_TEMPLATE = """
+SELECT
+    b.ProviderContactId,
+    c.ClientOfficeLocationName AS ServiceLocation,
+    COUNT(*)               AS Sessions,
+    MAX(b.ServiceEndTime)  AS LastServiceDate
+FROM [insights].[dw2].[BillingEntriesCurrent] AS b
+INNER JOIN [insights].[insights].[ServiceCode] AS sc
+    ON b.ServiceCodeId = sc.ServiceCodeId
+INNER JOIN [insights].[insights].[Client] AS c
+    ON b.ClientContactId = c.ClientId
+WHERE b.ServiceEndTime >= '{lookback_start}'
+  AND b.ServiceEndTime <  '{end_date}'
+  AND sc.ServiceCode IN ('97153', 'PDS | Technicians')
+  AND b.ProviderContactId IN ({provider_ids})
+GROUP BY b.ProviderContactId, c.ClientOfficeLocationName;
+"""


### PR DESCRIPTION
## What this does

BT roster tabs are driven by each provider's **CentralReach profile Office Location** field (`ProviderOfficeLocationName` -> `WorkLocation`). When a BT transfers clinics but that field isn't updated, they keep appearing on their **old** clinic's roster even though all their sessions are delivered elsewhere.

Example: Janya Quattlebaum has delivered 100% of her sessions at Monroe since May 11, but her CentralReach profile still lists Matthews, so she stays on the Matthews roster.

**Tab assignment is unchanged.** This is the business-requested "middle path": keep CentralReach as the source of truth for rosters, and add a review list that surfaces stale profiles to update.

## Changes

- **sql_queries.py** - `RECENT_SERVICE_LOCATION_SQL_TEMPLATE`: per-BT recent direct-service (97153 / `PDS | Technicians`) session counts by client office location, scoped to `{provider_ids}`.
- **pull_data.py** - `execute_recent_service_location_query` (45-day lookback anchored to now, independent of the pull's date range so it's stable during the days 1-5 previous-month run); `pull_data_main` now returns a 5-tuple.
- **location_review.py** (new) - `build_location_review`: flags a BT only when profile clinic differs from dominant recent service clinic AND total recent sessions >= 8 AND dominant clinic >= 60% of recent sessions (filters incidental cross-coverage).
- **merge_data.py** - writes a `LocationReview` tab right after `EmployeeLocationInCR`; placeholder note when nothing is flagged.
- **run_pipeline.py** - threads `recent_service_df` through to `merge_data_main`.

## Verification

Ran the full pipeline (all four phases) end-to-end on live current data, writing to a scratch workbook with the Google Drive copy stubbed out:

- Sheet order: `EmployeeLocationInCR` -> `LocationReview` -> clinic tabs.
- 17 BTs flagged, correct columns and values (Janya: Matthews vs Monroe, 100%, 74 sessions).
- Tab assignment preserved: flagged BTs still appear on their profile clinic's roster (Janya still on the Matthews tab); the flag is additive only.
- Merge + conditional-formatting pass completed without error.

Note: some flags are naming conventions rather than true transfers (e.g. profile "Blacksburg Faculty Clinic" vs billed "Blacksburg Clinic") - the tab is a review list for business to judge, not an automated move.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>