### PR TITLE
Fix BT clinic assignment: join CentralReach locations by contact ID

### DIFF
--- a/scripts_notebooks/prod/merge_data.py
+++ b/scripts_notebooks/prod/merge_data.py
@@ -130,6 +130,49 @@ def save_to_google_drive_folder(source_file: str, target_folder: str, logger: lo
     logger.info(f"Saved file to Google Drive folder: {target_file}")
 
 
+# The two candidate Drive roots the pipeline publishes to. The first is the macOS
+# CloudStorage path, the second the Windows drive letter; the publish helper tries
+# them in order, which is how the same code runs on either machine.
+GOOGLE_DRIVE_FOLDERS = (
+    '/Users/davidjcox/Library/CloudStorage/GoogleDrive-dcox@mosaictherapy.com/.shortcut-targets-by-id/10MVMkxZfVuZY9Q4RfE_vHZ2_kaQk85E-/RBT Supervision Tracking/DailyRBTTracking',
+    'G:/.shortcut-targets-by-id/10MVMkxZfVuZY9Q4RfE_vHZ2_kaQk85E-/RBT Supervision Tracking/DailyRBTTracking',
+)
+
+
+def publish_to_google_drive(output_file: str, save_to_archive: bool, logger: logging.Logger,
+                            push_to_drive: bool = True) -> None:
+    """
+    Copy the finished workbook into the shared Google Drive tracker folder.
+
+    This is the ONLY path that writes outside the repo, and it is business-facing:
+    save_to_google_drive_folder moves every other .xlsx in the live folder into
+    archived/ before copying the new one in, using os.path.basename(output_file) as
+    the name. Redirecting output_file alone does NOT keep a test run out of the
+    shared folder -- pass push_to_drive=False for that.
+
+    Args:
+        output_file: Local workbook to publish
+        save_to_archive: Publish into the archived/ subfolder instead of the live folder
+        logger: Logger instance
+        push_to_drive: When False, skip publishing entirely and log the skip
+    """
+    if not push_to_drive:
+        logger.info(f"push_to_drive=False, not publishing {os.path.basename(output_file)} to Google Drive")
+        return
+
+    save_fn = save_to_google_drive_archive_folder if save_to_archive else save_to_google_drive_folder
+    label = 'Google Drive archive folder' if save_to_archive else 'Google Drive folder'
+
+    last_error = None
+    for folder in GOOGLE_DRIVE_FOLDERS:
+        try:
+            save_fn(output_file, folder, logger)
+            return
+        except Exception as e:
+            last_error = e
+    logger.warning(f"Failed to save to {label}: {last_error}")
+
+
 def save_to_google_drive_archive_folder(source_file: str, target_folder: str, logger: logging.Logger):
     """
     Save the Excel file directly to Google Drive archived folder (for FINAL month files).
@@ -379,7 +422,7 @@ def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame =
                    employee_locations_df: pd.DataFrame = None, recent_service_df: pd.DataFrame = None,
                    transformed_file: str = None, bacb_file: str = None, save_file: bool = True,
                    output_file: str = None, save_to_archive: bool = False, archive_date: str = None,
-                   archive_file_exists: bool = False) -> pd.DataFrame:
+                   archive_file_exists: bool = False, push_to_drive: bool = True) -> pd.DataFrame:
     """
     Main function to merge data.
     
@@ -390,11 +433,18 @@ def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame =
         recent_service_df (pd.DataFrame, optional): Recent service-delivery locations from SQL query. Used to build the Location Review flag tab (does not affect tab assignment).
         transformed_file (str, optional): Transformed CSV file path. Used if transformed_df is None.
         bacb_file (str, optional): BACB CSV file path. Used if bacb_df is None.
-        save_file (bool): Whether to save file to disk. Default True.
+        save_file (bool): Whether to write the Excel workbook at all. Default True.
+            False skips every to_excel call AND the Drive publish.
         output_file (str, optional): Explicit output file path. If None, will use default naming.
+            NOTE: this controls only the LOCAL path. The Drive publish derives its
+            filename from basename(output_file), so redirecting this alone still writes
+            to the shared business folder -- set push_to_drive=False for a test run.
         save_to_archive (bool): If True, save to archived folder instead of main folder. Default False.
         archive_date (str, optional): Date string for _updated_{date} suffix when saving to archive. If None, uses today's date.
         archive_file_exists (bool): If True, existing file found and will use _updated suffix. If False, creates new file without suffix.
+        push_to_drive (bool): Whether to publish the workbook to the shared Google Drive
+            tracker folder. Default True (production behaviour). Pass False when
+            verifying pipeline changes so nothing reaches the business-facing folder.
         
     Returns:
         pd.DataFrame: Final merged DataFrame
@@ -651,28 +701,10 @@ def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame =
             wb.save(output_file)
             logger.info(f"Saved final merged data to Excel file: {output_file}")
             
-            # Save to Google Drive folder
-            google_drive_folder = '/Users/davidjcox/Library/CloudStorage/GoogleDrive-dcox@mosaictherapy.com/.shortcut-targets-by-id/10MVMkxZfVuZY9Q4RfE_vHZ2_kaQk85E-/RBT Supervision Tracking/DailyRBTTracking'
-            google_drive_folder2 = 'G:/.shortcut-targets-by-id/10MVMkxZfVuZY9Q4RfE_vHZ2_kaQk85E-/RBT Supervision Tracking/DailyRBTTracking'
-            
-            if save_to_archive:
-                # Save directly to Google Drive archived folder
-                try:
-                    save_to_google_drive_archive_folder(output_file, google_drive_folder, logger)
-                except Exception as e:
-                    try:
-                        save_to_google_drive_archive_folder(output_file, google_drive_folder2, logger)
-                    except Exception as e2:
-                        logger.warning(f"Failed to save to Google Drive archive folder: {e2}")
-            else:
-                # Save to main Google Drive folder (which will archive old files)
-                try:
-                    save_to_google_drive_folder(output_file, google_drive_folder, logger)
-                except Exception as e:
-                    try:
-                        save_to_google_drive_folder(output_file, google_drive_folder2, logger)
-                    except Exception as e2:
-                        logger.warning(f"Failed to save to Google Drive folder: {e2}")
+            # Publish to the shared Drive tracker folder. This is business-facing and
+            # is skipped entirely when push_to_drive is False -- see
+            # publish_to_google_drive for why redirecting output_file is not enough.
+            publish_to_google_drive(output_file, save_to_archive, logger, push_to_drive)
         elif 'Clinic' in final_df.columns:
             # Fallback: Group data by Clinic if WorkLocation is not available
             # Get unique clinics that actually have data
@@ -806,28 +838,10 @@ def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame =
             wb.save(output_file)
             logger.info(f"Saved final merged data to Excel file: {output_file}")
             
-            # Save to Google Drive folder
-            google_drive_folder = '/Users/davidjcox/Library/CloudStorage/GoogleDrive-dcox@mosaictherapy.com/.shortcut-targets-by-id/10MVMkxZfVuZY9Q4RfE_vHZ2_kaQk85E-/RBT Supervision Tracking/DailyRBTTracking'
-            google_drive_folder2 = 'G:/.shortcut-targets-by-id/10MVMkxZfVuZY9Q4RfE_vHZ2_kaQk85E-/RBT Supervision Tracking/DailyRBTTracking'
-            
-            if save_to_archive:
-                # Save directly to Google Drive archived folder
-                try:
-                    save_to_google_drive_archive_folder(output_file, google_drive_folder, logger)
-                except Exception as e:
-                    try:
-                        save_to_google_drive_archive_folder(output_file, google_drive_folder2, logger)
-                    except Exception as e2:
-                        logger.warning(f"Failed to save to Google Drive archive folder: {e2}")
-            else:
-                # Save to main Google Drive folder (which will archive old files)
-                try:
-                    save_to_google_drive_folder(output_file, google_drive_folder, logger)
-                except Exception as e:
-                    try:
-                        save_to_google_drive_folder(output_file, google_drive_folder2, logger)
-                    except Exception as e2:
-                        logger.warning(f"Failed to save to Google Drive folder: {e2}")
+            # Publish to the shared Drive tracker folder. This is business-facing and
+            # is skipped entirely when push_to_drive is False -- see
+            # publish_to_google_drive for why redirecting output_file is not enough.
+            publish_to_google_drive(output_file, save_to_archive, logger, push_to_drive)
         else:
             # Fallback: save as single sheet if Clinic column doesn't exist
             logger.warning("'Clinic' column not found, saving as single sheet")
@@ -940,28 +954,10 @@ def merge_data_main(transformed_df: pd.DataFrame = None, bacb_df: pd.DataFrame =
             wb.save(output_file)
             logger.info(f"Saved final merged data to: {output_file}")
             
-            # Save to Google Drive folder
-            google_drive_folder = '/Users/davidjcox/Library/CloudStorage/GoogleDrive-dcox@mosaictherapy.com/.shortcut-targets-by-id/10MVMkxZfVuZY9Q4RfE_vHZ2_kaQk85E-/RBT Supervision Tracking/DailyRBTTracking'
-            google_drive_folder2 = 'G:/.shortcut-targets-by-id/10MVMkxZfVuZY9Q4RfE_vHZ2_kaQk85E-/RBT Supervision Tracking/DailyRBTTracking'
-            
-            if save_to_archive:
-                # Save directly to Google Drive archived folder
-                try:
-                    save_to_google_drive_archive_folder(output_file, google_drive_folder, logger)
-                except Exception as e:
-                    try:
-                        save_to_google_drive_archive_folder(output_file, google_drive_folder2, logger)
-                    except Exception as e2:
-                        logger.warning(f"Failed to save to Google Drive archive folder: {e2}")
-            else:
-                # Save to main Google Drive folder (which will archive old files)
-                try:
-                    save_to_google_drive_folder(output_file, google_drive_folder, logger)
-                except Exception as e:
-                    try:
-                        save_to_google_drive_folder(output_file, google_drive_folder2, logger)
-                    except Exception as e2:
-                        logger.warning(f"Failed to save to Google Drive folder: {e2}")
+            # Publish to the shared Drive tracker folder. This is business-facing and
+            # is skipped entirely when push_to_drive is False -- see
+            # publish_to_google_drive for why redirecting output_file is not enough.
+            publish_to_google_drive(output_file, save_to_archive, logger, push_to_drive)
     
     logger.info("="*50)
     logger.info("Data merge completed successfully!")

--- a/scripts_notebooks/prod/pull_data.py
+++ b/scripts_notebooks/prod/pull_data.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pyodbc
 import os
 import json
+import hashlib
 import logging
 import re
 import argparse
@@ -206,6 +207,15 @@ def execute_bacb_query(conn, start_date: str, end_date: str) -> pd.DataFrame:
     return df
 
 
+def _employee_locations_query_fingerprint() -> str:
+    """
+    Short hash of the employee locations query text. Stored in the cache metadata so
+    that editing the query invalidates the cache -- the source-table timestamps alone
+    cannot detect that the cached CSV was produced by a different (e.g. buggy) query.
+    """
+    return hashlib.sha256(EMPLOYEE_LOCATIONS_SQL_TEMPLATE.encode('utf-8')).hexdigest()[:16]
+
+
 def _fetch_employee_locations_freshness(conn) -> Tuple[str, str]:
     """
     Run the cheap freshness check against Provider / Contacts and return the
@@ -270,20 +280,43 @@ def execute_employee_locations_query(conn, provider_ids: set) -> pd.DataFrame:
                 meta = json.load(f)
             cached_provider = meta.get('provider_row_modified_at')
             cached_contacts = meta.get('contacts_last_loaded_date')
-            if cached_provider is not None and cached_contacts is not None \
+            cached_query = meta.get('query_fingerprint')
+            if cached_query != _employee_locations_query_fingerprint():
+                logging.info(
+                    "Employee locations cache invalidated: query text changed since "
+                    "the cache was written; running full query"
+                )
+            elif cached_provider is not None and cached_contacts is not None \
                and cached_provider >= provider_iso \
                and cached_contacts >= contacts_iso:
                 df = pd.read_csv(_EMPLOYEE_LOCATIONS_CACHE_CSV)
+                # The cache is built for whatever provider set the previous run
+                # requested, so a hit is only valid if it covers every provider this
+                # run asked about. Otherwise the missing providers would silently get
+                # no WorkLocation and fall back to the client office location, which
+                # can split one BT across several clinic tabs. This bites the days-1-5
+                # previous-month run, whose provider set differs from the
+                # current-month run that most recently wrote the cache.
+                cached_ids = {int(pid) for pid in df['ProviderContactId'].dropna()}
+                missing = {int(pid) for pid in provider_ids} - cached_ids
+                if missing:
+                    logging.info(
+                        f"Employee locations cache covers {len(df)} rows but is missing "
+                        f"{len(missing)} of the {len(provider_ids)} requested providers; "
+                        "running full query"
+                    )
+                else:
+                    logging.info(
+                        f"Employee locations cache hit (provider<={cached_provider}, "
+                        f"contacts<={cached_contacts}); loaded {len(df)} rows from cache"
+                    )
+                    return df
+            else:
                 logging.info(
-                    f"Employee locations cache hit (provider<={cached_provider}, "
-                    f"contacts<={cached_contacts}); loaded {len(df)} rows from cache"
+                    f"Employee locations cache stale (cached provider={cached_provider}, "
+                    f"live={provider_iso}; cached contacts={cached_contacts}, live={contacts_iso}); "
+                    "running full query"
                 )
-                return df
-            logging.info(
-                f"Employee locations cache stale (cached provider={cached_provider}, "
-                f"live={provider_iso}; cached contacts={cached_contacts}, live={contacts_iso}); "
-                "running full query"
-            )
         except Exception as e:
             logging.warning(f"Failed to read employee locations cache, running full query: {e}")
 
@@ -301,6 +334,7 @@ def execute_employee_locations_query(conn, provider_ids: set) -> pd.DataFrame:
                 json.dump({
                     'provider_row_modified_at': provider_iso,
                     'contacts_last_loaded_date': contacts_iso,
+                    'query_fingerprint': _employee_locations_query_fingerprint(),
                     'refreshed_at': datetime.now().isoformat(),
                     'row_count': int(len(df)),
                 }, f, indent=2)

--- a/scripts_notebooks/prod/sql_queries.py
+++ b/scripts_notebooks/prod/sql_queries.py
@@ -100,31 +100,30 @@ GROUP BY b.ProviderContactId
 ORDER BY b.ProviderContactId;
 """
 
-# SQL query template for employee locations (maps provider names to office locations).
-# Pre-dedupes Provider in a CTE so the outer join input is smaller, and scopes the
-# Contacts side to a known set of ContactIds via the {provider_ids} placeholder
-# (a comma-separated list built from the direct/supervision/BACB pulls). Scoping
-# first avoids the full-table name-join cross-product that was timing out as the
-# tables grew. ORDER BY is dropped since downstream pandas code ignores row order.
+# SQL query template for employee locations (maps provider contact IDs to office
+# locations). Scoped to a known set of ContactIds via the {provider_ids} placeholder
+# (a comma-separated list built from the direct/supervision/BACB pulls) so the join
+# never runs as a full-table scan. ORDER BY is dropped since downstream pandas code
+# ignores row order.
+#
+# Joined on Provider.ProviderId = Contacts.ContactId -- these are the same
+# CentralReach contact identifier. An earlier version joined on
+# FirstName + LastName, which returned MULTIPLE rows for any provider sharing a name
+# with another provider record (e.g. two distinct "Emma Smith" employees, or one
+# active + one deactivated record). merge_data.add_work_locations_from_sql builds a
+# ProviderContactId -> WorkLocation dict, so a duplicated ID was resolved
+# last-row-wins and could silently place a BT on the wrong clinic tab. Verified over
+# the current provider set: the ID join matches all the same contacts (791/791) with
+# zero name mismatches and no duplicate IDs.
 EMPLOYEE_LOCATIONS_SQL_TEMPLATE = """
-WITH p AS (
-    SELECT DISTINCT
-        ProviderFirstName,
-        ProviderLastName,
-        ProviderOfficeLocationName
-    FROM [insights].[insights].[Provider]
-    WHERE ProviderFirstName IS NOT NULL
-      AND ProviderLastName IS NOT NULL
-)
-SELECT DISTINCT
+SELECT
     c.ContactId AS ProviderContactId,
     c.FirstName AS ProviderFirstName,
     c.LastName AS ProviderLastName,
     p.ProviderOfficeLocationName AS WorkLocation
 FROM [insights].[dw2].[Contacts] AS c
-INNER JOIN p
-    ON p.ProviderFirstName = c.FirstName
-   AND p.ProviderLastName = c.LastName
+INNER JOIN [insights].[insights].[Provider] AS p
+    ON p.ProviderId = c.ContactId
 WHERE c.ContactId IN ({provider_ids});
 """
 


### PR DESCRIPTION
## Why

Emma "Lee" Smith (contact `4054233`) is an active RBT at **PED Kernersville**, but the July supervision report listed her under **RAL Northeast Raleigh**, so the compliance flag was routed to a clinic that had never heard of her.

There are two `Emma Smith` records in CentralReach — the active RBT at Kernersville, and a separate deactivated one at Northeast Raleigh. `EMPLOYEE_LOCATIONS_SQL_TEMPLATE` joined `Provider` to `Contacts` on `FirstName + LastName`, so both matched the one contact. `merge_data.add_work_locations_from_sql` builds a `ProviderContactId -> WorkLocation` dict, so the duplicate was resolved last-row-wins and Raleigh happened to win.

The name join was inherited: `6f5976a` switched the location source from `insights.Employee` to `insights.Provider` but kept the old join predicate. `Provider` has a real key.

## Changes

1. **Join on `Provider.ProviderId = Contacts.ContactId`** — the same CentralReach identifier.
2. **Fingerprint the query text in the cache metadata** — the cache was keyed only on source-table timestamps, so it would have kept serving rows built by the old query.
3. **Require a cache hit to cover every requested provider** — the cache was never keyed on *which* providers were asked for. A run whose provider set exceeded the cached one silently got no `WorkLocation` for the extras and fell back to the client office location, splitting one BT across several clinic tabs. Over July the cache was missing **105 of 882** providers and **13 BTs were split**, adding 17 duplicate rows.
4. **Add `push_to_drive` (default `True`)** — `save_file=True` always published to the shared Drive folder, and `output_file` did not opt out of it, which makes the pipeline unsafe to test. Also collapses the publish logic, which was triplicated across three save branches.

## Verification

| Check | Result |
|---|---|
| Join equivalence, all 2,716 providers who billed since 2023-08 | same 2,716 contacts matched, same 2,707 with a location — **0 lost, 0 gained**, 36 fewer rows (all spurious duplicates) |
| `Provider` key integrity | 4,099 rows / 4,099 distinct `ProviderId` / all match a `ContactId` / 0 name disagreements |
| Ambiguous providers under the old join | 28 had 2+ conflicting locations; all now resolve to one |
| Workbook, July (`push_to_drive=False`) | 42 sheets, 735 providers, **0 on more than one clinic tab**, Emma Smith on `NC \| PED \| Kernersville` |
| Workbook, Aug-to-date | 666 rows, 666 providers, **0 on more than one tab** |
| Drive folder during test run | byte-untouched — same file, same md5, no stray files |

Three providers move to their correct clinic: Emma Smith to PED Kernersville, `1304733` to CLT Ayrsley, `4186780` to PED Winston Salem East.

## Not included

`DIRECT_SERVICES_SQL_TEMPLATE` still name-joins `Employee` for the BCBA exclusion. One name group is genuinely ambiguous (two `Kaitlin Mitchell` records, one BCBA); the BCBA billed 3 direct entries, last on 2025-10-02, and both records are now inactive. `Employee.EmployeeId` also equals `ContactId`, so it is the same one-line fix — left out to keep this PR to one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)