### PR TITLE
Exclude BCBAs from direct service by contact ID, not name

### DIFF
--- a/scripts_notebooks/prod/sql_queries.py
+++ b/scripts_notebooks/prod/sql_queries.py
@@ -11,7 +11,15 @@ start_date = '{start_date}'
 end_date = '{end_date}'
 
 # SQL query template for direct service data (ServiceCode = '97153')
-# Excludes BCBAs from being direct providers
+# Excludes BCBAs from being direct providers.
+#
+# The Employee join is on EmployeeId = ProviderContactId (same CentralReach contact
+# identifier; Employee is 1:1 on it). It previously joined on EmployeeFirstName +
+# EmployeeLastName, which fanned out for the 36 duplicated staff names: because this
+# is a LEFT JOIN feeding SELECT DISTINCT, one non-BCBA namesake row was enough to let
+# a BCBA's own entries through the WHERE filter. Kept as a LEFT JOIN with the
+# IS NULL branch below so providers absent from Employee are still treated as direct
+# providers rather than silently dropped.
 DIRECT_SERVICES_SQL_TEMPLATE = f"""
 SELECT DISTINCT
     b.BillingEntryId,
@@ -33,8 +41,7 @@ INNER JOIN [insights].[insights].[Client] AS c
 LEFT JOIN [insights].[dw2].[Contacts] AS pdir
     ON pdir.ContactId = b.ProviderContactId
 LEFT JOIN [insights].[insights].[Employee] AS e
-    ON e.EmployeeFirstName = pdir.FirstName
-   AND e.EmployeeLastName = pdir.LastName
+    ON e.EmployeeId = b.ProviderContactId
 WHERE b.ServiceEndTime >= '{start_date}'
   AND b.ServiceEndTime <  '{end_date}'
   AND sc.ServiceCode IN ('97153', 'PDS | Technicians')


### PR DESCRIPTION
Follow-up to #38, same root cause in the other query that name-joins CentralReach tables.

## Why

`DIRECT_SERVICES_SQL_TEMPLATE` filtered BCBAs out of the direct-provider set by joining `insights.Employee` on `EmployeeFirstName + EmployeeLastName`. 36 staff name groups have more than one `Employee` row, and since this is a `LEFT JOIN` feeding `SELECT DISTINCT`, one non-BCBA namesake row was enough to let a BCBA's own billing entries pass the `WHERE` filter — putting a BCBA on the tracker as a direct provider.

## Change

Join on `EmployeeId = ProviderContactId`. Same CentralReach contact identifier, and `Employee` is 1:1 on it (3,993 rows / 3,993 distinct `EmployeeId`).

Deliberately still a `LEFT JOIN` with the existing `EmploymentPosition IS NULL` branch, so a provider with no `Employee` row stays a direct provider. The failure direction remains "include" rather than "lose someone's hours".

## Verification

Over every provider with direct-service billing since 2023-08 (2,468 providers), **exactly one** changes classification:

| Provider | Before | After |
|---|---|---|
| Kaitlin Mitchell (`3002565`), the BCBA of two same-named records | included | excluded |

No provider moves the other way, so nothing is newly included and no direct hours are lost. Running the edited query confirms it — her 3 entries disappear from the October 2025 window, and July 2026 is unchanged at 31,273 rows / 811 providers, matching the pre-fix pull exactly.

Both her records are already inactive and her last direct entry was 2025-10-02, so no current report changes. This is hardening against the next duplicate name rather than a fix with visible output today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)